### PR TITLE
Use release tag name instead of target_commitish

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ module.exports = robot => {
     // Kick off a deployment through buildkite
     const {login} = release.author;
     const {name, ssh_url} = context.payload.repository;
-    const {target_commitish} = context.payload.release;
     const curlCommand = `curl \
       -H "Authorization: Bearer ${process.env.BUILDKITE_TOKEN}" \
       -X POST "https://api.buildkite.com/v2/organizations/uberopensource/pipelines/npm-deploy/builds" \

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = robot => {
           },
           "env": {
             "PUBLISH_REPO": "${ssh_url}",
-            "TARGET_COMMITISH": "${target_commitish}"
+            "TARGET_COMMITISH": "${release.tag_name}"
           }
         }'`;
 


### PR DESCRIPTION
This should be more reliable as target_commitish could theoretically reference a branch name. In this case, there's more likely to be a race condition (i.e. a commit is pushed to the same branch before the repo is cloned)

Someone deleting a tag then creating a new tag with the same name is much less likely.